### PR TITLE
Iterate hector accepting one parameter

### DIFF
--- a/R/iterate_hector.R
+++ b/R/iterate_hector.R
@@ -102,7 +102,8 @@ metric_calc_1run <- function(x, metric) {
 #' params
 #'
 #' # Iterate Hector runs with parameter uncertainty
-#' h_result <- iterate_hector(core, params)
+#' h_result <- iterate_hector(core, params, save_years = 1900:2100,
+#' save_vars = c(GLOBAL_TAS(), CONCENTRATIONS_CO2()))
 #' head(h_result)
 
 iterate_hector <- function(core,

--- a/R/iterate_hector.R
+++ b/R/iterate_hector.R
@@ -113,29 +113,28 @@ iterate_hector <- function(core,
   # store results
   result_list <- list()
 
-  # iterate hector across all param values
   for (i in seq_len(nrow(params))) {
 
-    # If ncol == 1, parameter names need to be added to establish correct input
-    # for set_params()
+    # If ncol > 1, names are correctly set in set_params()
+    # If ncol == 1, parameter names need to be set to establish correct input
     if (ncol(params) == 1) {
 
-      # convert params to numeric vector
-      single_param_values <- params[, 1]
+    # create new vector of the i-th row of the params df
+    single_param_vals <- params[i, ]
 
-      # Get names associated with each value in the vector
-      # This is the name of the parameter
-      names(single_param_values) <-
-        rep(colnames(params), length(single_param_values))
+    # set names for single_param_vals
+    # names are needed for set_params() to recognize the function name of the
+    # parameter.
+    single_param_vals <- setNames(single_param_vals, colnames(params))
 
-      # set variable values -- needs core and numeric param values
-      set_params(core, single_param_values)
+    # set variable values -- needs core and numeric param values
+    set_params(core, single_param_vals)
 
     # If ncol > 1, unlist parameters, names are correctly set in set_params()
     } else {
 
-      # convert params to numeric
-      params_i <- unlist(params [i,])
+      # convert groups of param perturbations
+      params_i <- unlist(params [i, ])
 
       # set variable values -- needs core and numeric param values
       set_params(core, params_i)

--- a/man/iterate_hector.Rd
+++ b/man/iterate_hector.Rd
@@ -4,7 +4,7 @@
 \alias{iterate_hector}
 \title{Iterate Hector Runs}
 \usage{
-iterate_hector(core, params, save_years = 1745:2300, save_vars = NULL)
+iterate_hector(core, params, save_years = NULL, save_vars = NULL)
 }
 \arguments{
 \item{core}{A core object to initiate Hector runs.}
@@ -32,6 +32,7 @@ params <- generate_params(core, 10)
 params
 
 # Iterate Hector runs with parameter uncertainty
-h_result <- iterate_hector(core, params)
+h_result <- iterate_hector(core, params, save_years = 1900:2100,
+save_vars = c(GLOBAL_TAS(), CONCENTRATIONS_CO2()))
 head(h_result)
 }

--- a/vignettes/matilda-vignette.Rmd
+++ b/vignettes/matilda-vignette.Rmd
@@ -63,6 +63,17 @@ print(param_values)
 
 We now have a data frame object with 10 random values sampled for each parameter.
 
+It may be of interest to the user to only apply changes to a few model parameters while keeping the other static. We can easily enforce this type of control by manipulating which columns in our `param_values` data frame. For example, if we are only interested in perturbing CO~2~ fertilization and ocean heat diffusivity (parameters `BETA()` and `DIFFUSIVITY()`, respectively), we can simply drop all other columns in the `param_values` data frame.
+
+```{r}
+# producing data frame to only manipulate the BETA parameter
+alter_beta_diff <- param_values [c(1, 5)]
+
+print(alter_beta_diff)
+```
+
+In these cases, only the parameters included in the subsetted data frame will be altered during Hector runs. All other parameters will follow Hector defaults.
+
 # Running Hector iteratively
 
 The `iterate_hector()` runs Hector multiple times, setting new parameter values with each iteration, and combining the results for easy analysis.


### PR DESCRIPTION
Tried to use:
`single_param <- params[i, , drop = FALSE]`
but was still getting some errors that are thrown in `set_params()`. 
I think the root of the error is either in `set_params` or in `generate_params` because the `str` of the object being passed to `set_params` is a df and not recognized as numeric.